### PR TITLE
Add `dependabot` Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    target-branch: "main"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "mike-weiner"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Closes #3.

This PR adds a basic `dependabot` config. Weekly runs will take place and open PRs to help me keep the project's dependencies up-to-date.