### PR TITLE
Remove Middleware No Longer Needed w/ Kamal Deployments

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,9 +1,0 @@
-import { NextResponse } from 'next/server';
-
-export function middleware(req, ev) {
-    if (process.env.NODE_ENV === 'production' && (!req.headers.get('x-forwarded-proto').includes('https'))) {
-        return NextResponse.redirect(`https://${req.headers.get('host')}${req.nextUrl.pathname}`, 301);
-    }
-
-    return NextResponse.next();
-}


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/kenyonwx/issues/65

The custom middleware that was originally written to ensure no `http` requests were served on Heroku is no longer needed.