### PR TITLE
Ensure `hosts` Is Used Throughout Kamal Config Overlays

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,6 +1,7 @@
 proxy:
   ssl: true
-  host: staging.kenyonwx.com
+  hosts: 
+    - staging.kenyonwx.com
   app_port: 3013
 
 env:


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/kenyonwx/issues/65

This fixes a small bug in the configuration as Kamal requires the same key (`host` or `hosts`) in the base deployment configuration and any overlay destination configurations.
