### PR TITLE
Bump `memcached` up to `v1.6.34`

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -44,6 +44,6 @@ ssh:
 
 accessories:
   memcached:
-    image: memcached:1.6.31
+    image: memcached:1.6.34
     host: 24.144.66.105
     port: "127.0.0.1:11211:11211"


### PR DESCRIPTION
This PR:

- Updates the `memcached` dependency up to `v1.6.34`.