### PR TITLE
Bump Container Images to `node:23`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim AS builder
+FROM node:23-slim AS builder
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ COPY . .
 
 RUN npm run build
 
-FROM node:22-slim
+FROM node:23-slim
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS builder
+FROM node:23-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Follow up to: https://github.com/mike-weiner/kenyonwx/pull/110

By bumping Node engine up to `23.x`, I should have also bumped the container images up to `node:23`. This PR cleans that up.