### PR TITLE
Bump `memcached` to `v1.6.35` & Set Container Limits

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -44,6 +44,10 @@ ssh:
 
 accessories:
   memcached:
-    image: memcached:1.6.34
+    image: memcached:1.6.35
     host: 24.144.66.105
     port: "127.0.0.1:11211:11211"
+    options:
+      conn-limit: 512
+      memory-limit: 256m
+      threads: 4


### PR DESCRIPTION
Resolves https://github.com/mike-weiner/kenyonwx/issues/115.

This PR bumps up to the latest patch release of `memcached`. In addition, I'm going to get some hard limits on `memcached` to prevent it from running wild.


References:
- https://kamal-deploy.org/docs/configuration/accessories/#options
- https://docs.memcached.org