### PR TITLE
Correct Config to Set `memcached` and `docker` Constraints Properly

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -47,7 +47,7 @@ accessories:
     image: memcached:1.6.35
     host: 24.144.66.105
     port: "127.0.0.1:11211:11211"
+    cmd: --conn-limit 100 --memory-limit 256m --threads 4
     options:
-      conn-limit: 512
-      memory-limit: 256m
-      threads: 4
+      cpus: 0.5
+      memory: 256m


### PR DESCRIPTION
Follow up to https://github.com/mike-weiner/kenyonwx/pull/116.

I incorrectly set the `memcached` container options in the `options:` field. Those needed to be set in the `cmd` field. This PR fixes that.