### PR TITLE
Bump up to Node `v24.x` && Disable Next.js Telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM node:23-slim AS builder
+FROM node:24-slim AS builder
 
 WORKDIR /app
 
 ENV NODE_ENV=production
+# Disable Next.js Telemetry
+ENV NEXT_TELEMETRY_DISABLED=1 
 
 COPY package.json ./
 COPY package-lock.json ./
@@ -13,7 +15,7 @@ COPY . .
 
 RUN npm run build
 
-FROM node:23-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,9 @@
-FROM node:23-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
+
+# Disable Next.js Telemetry
+ENV NEXT_TELEMETRY_DISABLED=1 
 
 COPY package.json ./
 COPY package-lock.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "tailwindcss": "^4.1.11"
       },
       "engines": {
-        "node": "23.x"
+        "node": "24.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Michael Weiner",
   "license": "MIT",
   "engines": {
-    "node": "23.x"
+    "node": "24.x"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",


### PR DESCRIPTION
Closes #187. 

This PR: 
- Bumps the `kenyonwx` project up to use Node v24.x.
- Disables Next.js Telemetry inside of our container image builds.